### PR TITLE
Notify when the queue changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Style/FileName:
 
 Style/Documentation:
   Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/spec/lita/handlers/queue_spec.rb
+++ b/spec/lita/handlers/queue_spec.rb
@@ -47,10 +47,21 @@ describe Lita::Handlers::Queue, lita_handler: true do
       end
     end
 
-    context "when I'm not on queue" do
+    context "when I'm not on queue, and the queue has someone else" do
+      before { subject.store_queue(room, ['someone']) }
+
       it 'replies with a confirmation message' do
         send_command('queue me', from: room)
         expect(replies.last).to include("#{user.name} have been added to queue")
+        expect(subject.fetch_queue(room)).to include(user.mention_name)
+      end
+    end
+
+    context "when I'm not on queue, and the queue is empty" do
+      it 'replies with a confirmation message' do
+        send_command('queue me', from: room)
+        expect(replies).to include("#{user.name} have been added to queue.")
+        expect(replies).to include("#{user.name} is the next. Go ahead!")
         expect(subject.fetch_queue(room)).to include(user.mention_name)
       end
     end


### PR DESCRIPTION
In order to integrate other plugins, I believe the simplest solution would be to trigger a lita event when the queue changes. That's what I did here: Any time someone is "next" on the queue, the `queue_change` event is triggered with the room, the user name and the queue.

I changed one detail in the current behavior. When the user queues himself, and he is, now, the only one there, besides from receive the "you've been added to queue" message, he also receives the "You are next, go ahead!".
